### PR TITLE
Fix trimmed zeros in transaction encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- Fix `to` address trimmed zeros in transaction encoder with unified hex encoding for transaction
+
 ## v0.3.0 (2024-02-05)
 
 ### Breaking Changes

--- a/lib/ethers/signer/local.ex
+++ b/lib/ethers/signer/local.ex
@@ -41,9 +41,9 @@ defmodule Ethers.Signer.Local do
       signed =
         %Ethers.Transaction{
           tx
-          | signature_r: r,
-            signature_s: s,
-            signature_y_parity_or_v: y_parity_or_v
+          | signature_r: Utils.hex_encode(r),
+            signature_s: Utils.hex_encode(s),
+            signature_y_parity_or_v: Utils.integer_to_hex(y_parity_or_v)
         }
         |> Transaction.encode()
         |> Utils.hex_encode()

--- a/lib/ethers/transaction.ex
+++ b/lib/ethers/transaction.ex
@@ -257,6 +257,9 @@ defmodule Ethers.Transaction do
 
   defp do_post_process(_key, {:error, reason}), do: {:error, reason}
 
+  defp hex_decode(""), do: ""
+  defp hex_decode("0x"), do: ""
+
   defp hex_decode("0x" <> _ = bin) do
     Utils.hex_decode!(bin)
   end

--- a/test/ethers/transaction_test.exs
+++ b/test/ethers/transaction_test.exs
@@ -81,5 +81,24 @@ defmodule Ethers.TransactionTest do
       assert "0x02eb8205390180851448baf2f58212349400008fdee72ac11b5c542428b35eef5769c409f080850006fdde03c0" ==
                Transaction.encode(transaction) |> Ethers.Utils.hex_encode()
     end
+
+    test "encodes transaction with empty data" do
+      transaction = %Ethers.Transaction{
+        type: :eip1559,
+        chain_id: "0x00539",
+        from: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1",
+        to: "0x00008FDEE72ac11b5c542428B35EEF5769C409f0",
+        nonce: "0x1",
+        gas: "0x1234",
+        value: "0x0",
+        data: "",
+        gas_price: "0x10e7467522",
+        max_fee_per_gas: "0x1448BAF2F5",
+        max_priority_fee_per_gas: "0x0"
+      }
+
+      assert "0x02e68205390180851448baf2f58212349400008fdee72ac11b5c542428b35eef5769c409f08080c0" ==
+               Transaction.encode(transaction) |> Ethers.Utils.hex_encode()
+    end
   end
 end

--- a/test/ethers/transaction_test.exs
+++ b/test/ethers/transaction_test.exs
@@ -61,4 +61,25 @@ defmodule Ethers.TransactionTest do
                Transaction.decode_values(%{@transaction_fixture | signature_y_parity_or_v: ""})
     end
   end
+
+  describe "encode/1" do
+    test "encodes transaction with address having leading zeros" do
+      transaction = %Ethers.Transaction{
+        type: :eip1559,
+        chain_id: "0x00539",
+        from: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1",
+        to: "0x00008FDEE72ac11b5c542428B35EEF5769C409f0",
+        nonce: "0x1",
+        gas: "0x1234",
+        value: "0x0",
+        data: "0x0006fdde03",
+        gas_price: "0x10e7467522",
+        max_fee_per_gas: "0x1448BAF2F5",
+        max_priority_fee_per_gas: "0x0"
+      }
+
+      assert "0x02eb8205390180851448baf2f58212349400008fdee72ac11b5c542428b35eef5769c409f080850006fdde03c0" ==
+               Transaction.encode(transaction) |> Ethers.Utils.hex_encode()
+    end
+  end
 end


### PR DESCRIPTION
We don't need to trim zeros if we:

1. Make sure the transaction data will always be hex encoded starting with '0x' AND
2. Pass them as integers to `ExRLP.encode/1`


Using the existing `trim_leading/1` on all transaction values is dangerous as it can alter the transaction. For example a transaction `data` starting with one or more zero(s) or transaction `to` address which start with one or more zero(s) is perfectly fine. Since ExRLP already handles integers, we need to pass these transaction parameters as integers so we get the correct RLP encoding.

Closes #91 