### PR TITLE
Support signed raw transactions in `Ethers.send/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Support sending raw transactions using `Ethers.send/2`
+
 ## v0.4.1 (2024-04-02)
 
 ### Enhancements

--- a/lib/ethers.ex
+++ b/lib/ethers.ex
@@ -599,6 +599,10 @@ defmodule Ethers do
     end
   end
 
+  defp pre_process("0x" <> _ = signed_tx, _overrides, :send, _opts) do
+    {:ok, signed_tx, :eth_send_raw_transaction}
+  end
+
   defp pre_process(tx_data, overrides, :send = action, opts) do
     tx_params = TxData.to_map(tx_data, overrides)
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,8 @@ defmodule Ethers.MixProject do
         coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
-        "coveralls.html": :test
+        "coveralls.html": :test,
+        test_prepare: :test
       ],
       description:
         "A comprehensive Web3 library for interacting with smart contracts on Ethereum using Elixir.",

--- a/test/ethers_test.exs
+++ b/test/ethers_test.exs
@@ -473,7 +473,7 @@ defmodule EthersTest do
                  tx_type: :eip1559
                )
 
-      assert {:ok, _tx_hash} = Ethers.rpc_client().eth_send_raw_transaction(signed)
+      assert {:ok, _tx_hash} = Ethers.send(signed)
 
       assert {:ok, "hi signed"} = Ethers.call(HelloWorldContract.say_hello(), to: address)
     end


### PR DESCRIPTION
This will be useful in broadcasting signed transactions.