### PR TITLE
Implement ERC-165 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Add ERC-165 contract and behaviour
+- Add `skip_docs` option for contract module doc and typespec generation
+
 ## v0.4.3 (2024-04-05)
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Ethers already includes some of the well-known contract interface standards for 
 Here is a list of them.
 
 - [ERC20](https://hexdocs.pm/ethers/Ethers.Contracts.ERC20.html) - The well know fungible token standard
+- [ERC165](https://hexdocs.pm/ethers/Ethers.Contracts.ERC165.html) - Standard Interface detection
 - [ERC721](https://hexdocs.pm/ethers/Ethers.Contracts.ERC721.html) - Non-Fungible tokens (NFTs) standard
 - [ERC777](https://hexdocs.pm/ethers/Ethers.Contracts.ERC777.html) - Improved fungible token standard
 - [ERC1155](https://hexdocs.pm/ethers/Ethers.Contracts.ERC1155.html) - Multi-Token standard (Fungible, Non-Fungible or Semi-Fungible)

--- a/lib/ethers/contracts/erc1155.ex
+++ b/lib/ethers/contracts/erc1155.ex
@@ -2,8 +2,16 @@ defmodule Ethers.Contracts.ERC1155 do
   @moduledoc """
   ERC1155 token interface
 
-  More info: https://ethereum.org/en/developers/docs/standards/tokens/erc-1155/
+  More info: https://eips.ethereum.org/EIPS/eip-1155
   """
 
   use Ethers.Contract, abi: :erc1155
+
+  @behaviour Ethers.Contracts.ERC165
+
+  # ERC-165 Interface ID
+  @interface_id Ethers.Utils.hex_decode!("0xd9b67a26")
+
+  @impl Ethers.Contracts.ERC165
+  def erc165_interface_id, do: @interface_id
 end

--- a/lib/ethers/contracts/erc165.ex
+++ b/lib/ethers/contracts/erc165.ex
@@ -3,8 +3,31 @@ defmodule Ethers.Contracts.ERC165 do
   ERC-165 Standard Interface Detection
 
   More info: https://eips.ethereum.org/EIPS/eip-165
+
+  ## Modules as Interface IDs
+
+  Contract modules can opt to implement EIP-165 behaviour so that their name can be used
+  directly with the `supports_interface/1` function in this module. See below example:
+
+  ```elixir
+  defmodule MyEIP165CompatibleContract do
+    use Ethers.Contract, abi: ...
+    @behaviour Ethers.Contracts.ERC165
+
+    @impl true
+    def erc165_interface_id, do: Ethers.Utils.hex_decode("[interface_id]")
+  end
+  ```
+
+  Now module name can be used instead of interface_id and will have the same result.
+
+  ```elixir
+  iex> Ethers.Contracts.ERC165.supports_interface("[interface_id]") ==
+    Ethers.Contracts.ERC165.supports_interface(MyEIP165CompatibleContract)
+  true
+  ```
   """
-  use Ethers.Contract, abi: :erc165
+  use Ethers.Contract, abi: :erc165, skip_docs: true
 
   @behaviour __MODULE__
 
@@ -19,12 +42,38 @@ defmodule Ethers.Contracts.ERC165 do
   @impl __MODULE__
   def erc165_interface_id, do: @interface_id
 
-  def supports_interface(iface) when is_atom(iface) do
-    supports_interface(iface.erc165_interface_id())
+  @doc """
+  Prepares `supportsInterface(bytes4 interfaceId)` call parameters on the contract.
+
+  This function also accepts a module that implements the ERC165 behaviour as input. Example:
+
+  ```elixir
+  iex> #{Macro.to_string(__MODULE__)}.supports_interface(Ethers.Contracts.ERC721)
+  #Ethers.TxData<function supportsInterface(...)>
+  ```
+
+  This function should only be called for result and never in a transaction on
+  its own. (Use Ethers.call/2)
+
+  State mutability: view
+
+  ## Function Parameter Types
+
+  - interfaceId: `{:bytes, 4}`
+
+  ## Return Types (when called with `Ethers.call/2`)
+
+  - :bool
+  """
+  @spec supports_interface(<<_::32>> | atom()) :: Ethers.TxData.t()
+  def supports_interface(module_or_interface_id)
+
+  def supports_interface(module) when is_atom(module) do
+    supports_interface(module.erc165_interface_id())
   rescue
     UndefinedFunctionError ->
       reraise NotERC165CompatibleError,
-              "module #{iface} does not implement ERC165 behaviour",
+              "module #{module} does not implement ERC165 behaviour",
               __STACKTRACE__
   end
 end

--- a/lib/ethers/contracts/erc165.ex
+++ b/lib/ethers/contracts/erc165.ex
@@ -1,0 +1,30 @@
+defmodule Ethers.Contracts.ERC165 do
+  @moduledoc """
+  ERC-165 Standard Interface Detection
+
+  More info: https://eips.ethereum.org/EIPS/eip-165
+  """
+  use Ethers.Contract, abi: :erc165
+
+  @behaviour __MODULE__
+
+  @callback erc165_interface_id() :: <<_::32>>
+
+  @interface_id Ethers.Utils.hex_decode!("0x01ffc9a7")
+
+  defmodule NotERC165CompatibleError do
+    defexception [:message]
+  end
+
+  @impl __MODULE__
+  def erc165_interface_id, do: @interface_id
+
+  def supports_interface(iface) when is_atom(iface) do
+    supports_interface(iface.erc165_interface_id())
+  rescue
+    UndefinedFunctionError ->
+      reraise NotERC165CompatibleError,
+              "module #{iface} does not implement ERC165 behaviour",
+              __STACKTRACE__
+  end
+end

--- a/lib/ethers/contracts/erc721.ex
+++ b/lib/ethers/contracts/erc721.ex
@@ -9,7 +9,7 @@ defmodule Ethers.Contracts.ERC721 do
 
   @behaviour Ethers.Contracts.ERC165
 
-  # Interface ID
+  # ERC-165 Interface ID
   @interface_id Ethers.Utils.hex_decode!("0x80ac58cd")
 
   @impl Ethers.Contracts.ERC165

--- a/lib/ethers/contracts/erc721.ex
+++ b/lib/ethers/contracts/erc721.ex
@@ -2,8 +2,16 @@ defmodule Ethers.Contracts.ERC721 do
   @moduledoc """
   ERC721 token interface
 
-  More info: https://ethereum.org/en/developers/docs/standards/tokens/erc-721/
+  More info: https://eips.ethereum.org/EIPS/eip-721
   """
 
   use Ethers.Contract, abi: :erc721
+
+  @behaviour Ethers.Contracts.ERC165
+
+  # Interface ID
+  @interface_id Ethers.Utils.hex_decode!("0x80ac58cd")
+
+  @impl Ethers.Contracts.ERC165
+  def erc165_interface_id, do: @interface_id
 end

--- a/priv/abi/erc165.json
+++ b/priv/abi/erc165.json
@@ -1,0 +1,23 @@
+[
+  {
+    "inputs":
+    [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs":
+    [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
Closes #108

[EIP-165](https://eips.ethereum.org/EIPS/eip-165) provides a way to check if a contract supports a specific interface or not.

This PR adds:
- Separate `Ethers.Contracts.ERC165` contract
- A behaviour for other contracts supporting ERC165 interface checks to expose their interface ID.
- Support calling  `Ethers.Contracts.ERC165.supports_interface/1` with modules implementing ERC165 behaviour instead of interface IDs directly.