### PR TITLE
Support raw results in `Ethers.call/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Enable raw use of `Ethers.call/2` (usage without function selector)
+
 ## v0.5.1 (2024-08-02)
 
 ### Enhancements

--- a/test/ethers_test.exs
+++ b/test/ethers_test.exs
@@ -599,4 +599,18 @@ defmodule EthersTest do
       end
     end
   end
+
+  describe "call/2" do
+    test "works without selector (raw call)" do
+      address = deploy(HelloWorldContract, from: @from)
+
+      tx_data = HelloWorldContract.say_hello()
+
+      assert {:ok,
+              "0x000000000000000000000000000000000000000000000000000000000000002000000000000" <>
+                "0000000000000000000000000000000000000000000000000000c48656c6c6f20576f726c642100" <>
+                "00000000000000000000000000000000000000"} =
+               Ethers.call(%{data: tx_data.data}, to: address)
+    end
+  end
 end


### PR DESCRIPTION
Enabling `Ethers.call/2` to be used without the selector makes it easier for users who rely on Ethers configuration to not directly access underlying RPC functionality when they don't have to.