### PR TITLE
Refactor `Utils.date_to_block_number/3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Handle `{:ok, nil}` from RPC get block by number request
+
 ### Enhancements
 
 - Enable raw use of `Ethers.call/2` (usage without function selector)
+- Add optional backoff to `Ethers.Utils.date_to_block_number/3`
 
 ## v0.5.1 (2024-08-02)
 


### PR DESCRIPTION
- Handles `nil` result from RPC (FIxes #134)
- Implements an optional backoff