### PR TITLE
Remove hexification of entries in TxData.to_map/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Remove hexification of map entries in `Ethers.TxData.to_map/2`
+
 ## v0.6.2 (2025-01-10)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enahncements
+
+- Strict type checking for initializing transaction structs
+
 ### Bug Fixes
 
 - Remove hexification of map entries in `Ethers.TxData.to_map/2`

--- a/lib/ethers/transaction/eip1559.ex
+++ b/lib/ethers/transaction/eip1559.ex
@@ -6,6 +6,8 @@ defmodule Ethers.Transaction.Eip1559 do
   See: https://eips.ethereum.org/EIPS/eip-1559
   """
 
+  import Ethers.Transaction.Helpers
+
   alias Ethers.Types
   alias Ethers.Utils
 
@@ -53,19 +55,29 @@ defmodule Ethers.Transaction.Eip1559 do
   @impl Ethers.Transaction
   def new(params) do
     to = params[:to]
+    input = params[:input] || params[:data] || ""
+    value = params[:value] || 0
 
-    {:ok,
-     %__MODULE__{
-       chain_id: params.chain_id,
-       nonce: params.nonce,
-       max_priority_fee_per_gas: params.max_priority_fee_per_gas,
-       max_fee_per_gas: params.max_fee_per_gas,
-       gas: params.gas,
-       to: to && Utils.to_checksum_address(to),
-       value: params[:value] || 0,
-       input: params[:input] || params[:data] || "",
-       access_list: params[:access_list] || []
-     }}
+    with :ok <- validate_non_neg_integer(params.chain_id),
+         :ok <- validate_non_neg_integer(params.nonce),
+         :ok <- validate_non_neg_integer(params.max_priority_fee_per_gas),
+         :ok <- validate_non_neg_integer(params.max_fee_per_gas),
+         :ok <- validate_non_neg_integer(params.gas),
+         :ok <- validate_non_neg_integer(value),
+         :ok <- validate_binary(input) do
+      {:ok,
+       %__MODULE__{
+         chain_id: params.chain_id,
+         nonce: params.nonce,
+         max_priority_fee_per_gas: params.max_priority_fee_per_gas,
+         max_fee_per_gas: params.max_fee_per_gas,
+         gas: params.gas,
+         to: to && Utils.to_checksum_address(to),
+         value: value,
+         input: input,
+         access_list: params[:access_list] || []
+       }}
+    end
   end
 
   @impl Ethers.Transaction

--- a/lib/ethers/transaction/eip2930.ex
+++ b/lib/ethers/transaction/eip2930.ex
@@ -9,6 +9,8 @@ defmodule Ethers.Transaction.Eip2930 do
   See: https://eips.ethereum.org/EIPS/eip-2930
   """
 
+  import Ethers.Transaction.Helpers
+
   alias Ethers.Types
   alias Ethers.Utils
 
@@ -53,18 +55,25 @@ defmodule Ethers.Transaction.Eip2930 do
   @impl Ethers.Transaction
   def new(params) do
     to = params[:to]
+    input = params[:input] || params[:data] || ""
+    value = params[:value] || 0
 
-    {:ok,
-     %__MODULE__{
-       chain_id: params.chain_id,
-       nonce: params.nonce,
-       gas_price: params.gas_price,
-       gas: params.gas,
-       to: to && Utils.to_checksum_address(to),
-       value: params[:value] || 0,
-       input: params[:input] || params[:data] || "",
-       access_list: params[:access_list] || []
-     }}
+    with :ok <- validate_common_fields(params),
+         :ok <- validate_non_neg_integer(params.gas_price),
+         :ok <- validate_non_neg_integer(value),
+         :ok <- validate_binary(input) do
+      {:ok,
+       %__MODULE__{
+         chain_id: params.chain_id,
+         nonce: params.nonce,
+         gas_price: params.gas_price,
+         gas: params.gas,
+         to: to && Utils.to_checksum_address(to),
+         value: value,
+         input: input,
+         access_list: params[:access_list] || []
+       }}
+    end
   end
 
   @impl Ethers.Transaction

--- a/lib/ethers/transaction/eip4844.ex
+++ b/lib/ethers/transaction/eip4844.ex
@@ -7,6 +7,8 @@ defmodule Ethers.Transaction.Eip4844 do
   See: https://eips.ethereum.org/EIPS/eip-4844
   """
 
+  import Ethers.Transaction.Helpers
+
   alias Ethers.Types
   alias Ethers.Utils
 
@@ -67,21 +69,30 @@ defmodule Ethers.Transaction.Eip4844 do
   @impl Ethers.Transaction
   def new(params) do
     to = params[:to]
+    input = params[:input] || params[:data] || ""
+    value = params[:value] || 0
 
-    {:ok,
-     %__MODULE__{
-       chain_id: params.chain_id,
-       nonce: params.nonce,
-       max_priority_fee_per_gas: params.max_priority_fee_per_gas,
-       max_fee_per_gas: params.max_fee_per_gas,
-       gas: params.gas,
-       to: to && Utils.to_checksum_address(to),
-       value: params[:value] || 0,
-       input: params[:input] || params[:data] || "",
-       access_list: params[:access_list] || [],
-       max_fee_per_blob_gas: params.max_fee_per_blob_gas,
-       blob_versioned_hashes: params[:blob_versioned_hashes] || []
-     }}
+    with :ok <- validate_common_fields(params),
+         :ok <- validate_non_neg_integer(params.max_priority_fee_per_gas),
+         :ok <- validate_non_neg_integer(params.max_fee_per_gas),
+         :ok <- validate_non_neg_integer(params.max_fee_per_blob_gas),
+         :ok <- validate_non_neg_integer(value),
+         :ok <- validate_binary(input) do
+      {:ok,
+       %__MODULE__{
+         chain_id: params.chain_id,
+         nonce: params.nonce,
+         max_priority_fee_per_gas: params.max_priority_fee_per_gas,
+         max_fee_per_gas: params.max_fee_per_gas,
+         gas: params.gas,
+         to: to && Utils.to_checksum_address(to),
+         value: value,
+         input: input,
+         access_list: params[:access_list] || [],
+         max_fee_per_blob_gas: params.max_fee_per_blob_gas,
+         blob_versioned_hashes: params[:blob_versioned_hashes] || []
+       }}
+    end
   end
 
   @impl Ethers.Transaction

--- a/lib/ethers/transaction/helpers.ex
+++ b/lib/ethers/transaction/helpers.ex
@@ -1,0 +1,33 @@
+defmodule Ethers.Transaction.Helpers do
+  @moduledoc false
+
+  @spec validate_non_neg_integer(term()) :: :ok | {:error, :expected_non_neg_integer_value}
+  def validate_non_neg_integer(value) when is_integer(value) and value >= 0, do: :ok
+  def validate_non_neg_integer(_), do: {:error, :expected_non_neg_integer_value}
+
+  @spec validate_binary(term()) :: :ok | {:error, :expected_binary_value}
+  def validate_binary(value) when is_binary(value), do: :ok
+  def validate_binary(_), do: {:error, :expected_binary_value}
+
+  @spec validate_address(term()) :: :ok | {:error, :invalid_address_length | :invalid_address}
+  def validate_address("0x" <> address) do
+    case Ethers.Utils.hex_decode(address) do
+      {:ok, <<_address_bin::binary-20>>} -> :ok
+      {:ok, _bad_address} -> {:error, :invalid_address_length}
+      _ -> {:error, :invalid_address}
+    end
+  end
+
+  def validate_address(nil), do: :ok
+  def validate_address(_invalid), do: {:error, :invalid_address}
+
+  @spec validate_common_fields(map()) ::
+          :ok | {:error, :expected_non_neg_integer_value | :expected_binary_value}
+  def validate_common_fields(params) do
+    with :ok <- validate_non_neg_integer(params.chain_id),
+         :ok <- validate_non_neg_integer(params.nonce),
+         :ok <- validate_address(params[:to]) do
+      validate_non_neg_integer(params.gas)
+    end
+  end
+end

--- a/lib/ethers/transaction/legacy.ex
+++ b/lib/ethers/transaction/legacy.ex
@@ -3,6 +3,8 @@ defmodule Ethers.Transaction.Legacy do
   Legacy transaction struct and implementation of Transaction.Protocol.
   """
 
+  import Ethers.Transaction.Helpers
+
   alias Ethers.Types
   alias Ethers.Utils
 
@@ -44,17 +46,24 @@ defmodule Ethers.Transaction.Legacy do
   @impl Ethers.Transaction
   def new(params) do
     to = params[:to]
+    input = params[:input] || params[:data] || ""
+    value = params[:value] || 0
 
-    {:ok,
-     %__MODULE__{
-       nonce: params.nonce,
-       gas_price: params.gas_price,
-       gas: params.gas,
-       to: to && Utils.to_checksum_address(to),
-       value: params[:value] || 0,
-       input: params[:input] || params[:data] || "",
-       chain_id: params[:chain_id]
-     }}
+    with :ok <- validate_common_fields(params),
+         :ok <- validate_non_neg_integer(params.gas_price),
+         :ok <- validate_non_neg_integer(value),
+         :ok <- validate_binary(input) do
+      {:ok,
+       %__MODULE__{
+         nonce: params.nonce,
+         gas_price: params.gas_price,
+         gas: params.gas,
+         to: to && Utils.to_checksum_address(to),
+         value: value,
+         input: input,
+         chain_id: params[:chain_id]
+       }}
+    end
   end
 
   @impl Ethers.Transaction

--- a/lib/ethers/tx_data.ex
+++ b/lib/ethers/tx_data.ex
@@ -46,12 +46,7 @@ defmodule Ethers.TxData do
   end
 
   def to_map(tx_map, overrides) when is_map(tx_map) do
-    overrides
-    |> Enum.into(tx_map)
-    |> Map.new(fn
-      {k, v} when is_integer(v) -> {k, Ethers.Utils.integer_to_hex(v)}
-      kv -> kv
-    end)
+    Enum.into(overrides, tx_map)
   end
 
   @doc """

--- a/test/ethers/tx_data_test.exs
+++ b/test/ethers/tx_data_test.exs
@@ -45,7 +45,7 @@ defmodule Ethers.TxDataTest do
     test "integer overrides are converted to hex" do
       tx_data = TxData.new("0xffff", @function_selector, nil, nil)
 
-      assert %{data: "0xffff", gas: "0x1"} ==
+      assert %{data: "0xffff", gas: 1} ==
                TxData.to_map(tx_data, gas: 1)
     end
   end


### PR DESCRIPTION
This was no longer needed and is now causing issues when a user wants to specify overrides.