### PR TITLE
Refactor and remove unnecessary hex encode/decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- `Ethers.TxData` uses hex_decoded values instead of hex encoded ones
+
+### Enhancements
+
+- Update `Ethers` module to RPCfy eth_call request params
+- Removed unnecessary hex decode/encodes in requests
+
 ## v0.6.3 (2025-01-21)
 
 ### Enahncements

--- a/lib/ethers.ex
+++ b/lib/ethers.ex
@@ -681,7 +681,7 @@ defmodule Ethers do
     tx_params = TxData.to_map(tx_data, overrides)
 
     case check_params(tx_params, :call) do
-      :ok -> {:ok, tx_params, block}
+      :ok -> {:ok, Transaction.to_rpc_map(tx_params), block}
       err -> err
     end
   end
@@ -704,9 +704,11 @@ defmodule Ethers do
   defp pre_process(contract_binary, overrides, :deploy = _action, opts) do
     {encoded_constructor, overrides} = Keyword.pop(overrides, :encoded_constructor)
 
+    encoded_constructor = encoded_constructor || ""
+
     tx_params =
       Enum.into(overrides, %{
-        data: "0x#{contract_binary}#{encoded_constructor}",
+        data: contract_binary <> encoded_constructor,
         to: nil
       })
 

--- a/lib/ethers/ccip_read.ex
+++ b/lib/ethers/ccip_read.ex
@@ -54,7 +54,7 @@ defmodule Ethers.CcipRead do
            end)
            |> resolve_first(error) do
       data = ABI.TypeEncoder.encode([data, error.extra_data], [:bytes, :bytes])
-      tx_data = %{tx_data | data: Utils.hex_encode(error.callback_function <> data)}
+      tx_data = %{tx_data | data: error.callback_function <> data}
       Ethers.call(tx_data, opts)
     end
   end

--- a/lib/ethers/contract.ex
+++ b/lib/ethers/contract.ex
@@ -209,7 +209,6 @@ defmodule Ethers.Contract do
 
         unquote(Macro.escape(selector))
         |> ABI.encode(args)
-        |> Ethers.Utils.hex_encode(false)
       end
     end
   end
@@ -250,7 +249,6 @@ defmodule Ethers.Contract do
           |> Enum.map(fn {arg, type} -> Ethers.Utils.prepare_arg(arg, type) end)
 
         ABI.encode(selector, args)
-        |> Ethers.Utils.hex_encode()
         |> Ethers.TxData.new(selector, __default_address__(), __MODULE__)
       end
     end

--- a/lib/ethers/contract_helpers.ex
+++ b/lib/ethers/contract_helpers.ex
@@ -419,7 +419,10 @@ defmodule Ethers.ContractHelpers do
   end
 
   defp maybe_read_contract_binary(:abi, abi) when is_list(abi), do: nil
-  defp maybe_read_contract_binary(:abi, %{"bin" => bin}) when is_binary(bin), do: bin
+
+  defp maybe_read_contract_binary(:abi, %{"bin" => bin}) when is_binary(bin),
+    do: Ethers.Utils.hex_decode!(bin)
+
   defp maybe_read_contract_binary(:abi, map) when is_map(map), do: nil
   defp maybe_read_contract_binary(:abi, abi) when is_atom(abi), do: nil
 

--- a/lib/ethers/multicall.ex
+++ b/lib/ethers/multicall.ex
@@ -24,7 +24,7 @@ defmodule Ethers.Multicall do
   ```
   """
 
-  import Ethers.Utils, only: [hex_decode!: 1, human_arg: 2]
+  import Ethers.Utils, only: [human_arg: 2]
 
   alias Ethers.Contracts.Multicall3
   alias Ethers.TxData
@@ -98,7 +98,7 @@ defmodule Ethers.Multicall do
   def aggregate3_encode_data(data)
 
   def aggregate3_encode_data({%TxData{data: data} = tx_data, opts}) do
-    {fetch_address!(tx_data, opts), Keyword.get(opts, :allow_failure, true), hex_decode!(data)}
+    {fetch_address!(tx_data, opts), Keyword.get(opts, :allow_failure, true), data}
   end
 
   def aggregate3_encode_data(%TxData{} = tx_data), do: aggregate3_encode_data({tx_data, []})
@@ -163,7 +163,7 @@ defmodule Ethers.Multicall do
   def aggregate2_encode_data(data)
 
   def aggregate2_encode_data({%TxData{data: data} = tx_data, opts}) do
-    {fetch_address!(tx_data, opts), hex_decode!(data)}
+    {fetch_address!(tx_data, opts), data}
   end
 
   def aggregate2_encode_data(%TxData{} = tx_data), do: aggregate2_encode_data({tx_data, []})

--- a/lib/ethers/transaction.ex
+++ b/lib/ethers/transaction.ex
@@ -84,13 +84,7 @@ defmodule Ethers.Transaction do
   def new(params) do
     case Map.fetch(params, :type) do
       {:ok, type} when type in @transaction_types ->
-        input =
-          if input_hex = Map.get(params, :input, Map.get(params, :data)) do
-            Utils.hex_decode!(input_hex)
-          end
-
         params
-        |> Map.put(:input, input)
         |> type.new()
         |> maybe_wrap_signed(params)
 
@@ -308,13 +302,13 @@ defmodule Ethers.Transaction do
       t -> t
     end)
     |> Enum.map(fn
-      {field, "0x" <> _ = value} ->
-        {field, value}
-
       {field, nil} ->
         {field, nil}
 
-      {field, input} when field in [:data, :input, :from, :to] ->
+      {field, "0x" <> _ = value} when field in [:from, :to] ->
+        {field, value}
+
+      {field, input} when field in [:data, :input] ->
         {field, Utils.hex_encode(input)}
 
       {field, value} when is_integer(value) ->

--- a/lib/ethers/tx_data.ex
+++ b/lib/ethers/tx_data.ex
@@ -90,7 +90,7 @@ defmodule Ethers.TxData do
     alias Ethers.Utils
 
     def inspect(%{selector: selector, data: data, default_address: default_address}, opts) do
-      arguments = ABI.decode(selector, Utils.hex_decode!(data), :input)
+      arguments = ABI.decode(selector, data, :input)
 
       arguments_doc =
         Enum.zip([selector.types, input_names(selector), arguments])

--- a/test/ethers/counter_contract_test.exs
+++ b/test/ethers/counter_contract_test.exs
@@ -10,6 +10,7 @@ defmodule Ethers.CounterContractTest do
   import Ethers.TestHelpers
 
   alias Ethers.Event
+  alias Ethers.Utils
 
   alias Ethers.Contract.Test.CounterContract
 
@@ -122,7 +123,7 @@ defmodule Ethers.CounterContractTest do
     test "calling view functions", %{address: address} do
       assert %Ethers.TxData{
                base_module: CounterContract,
-               data: "0x6d4ce63c",
+               data: Utils.hex_decode!("0x6d4ce63c"),
                selector: %ABI.FunctionSelector{
                  function: "get",
                  method_id: <<109, 76, 230, 60>>,
@@ -142,7 +143,9 @@ defmodule Ethers.CounterContractTest do
     end
 
     test "sending transaction with state mutating functions", %{address: address} do
-      {:ok, tx_hash} = CounterContract.set(101) |> Ethers.send_transaction(from: @from, to: address)
+      {:ok, tx_hash} =
+        CounterContract.set(101) |> Ethers.send_transaction(from: @from, to: address)
+
       wait_for_transaction!(tx_hash)
 
       {:ok, 101} = CounterContract.get() |> Ethers.call(to: address)
@@ -160,7 +163,9 @@ defmodule Ethers.CounterContractTest do
 
     test "returns error if to address is not given" do
       assert {:error, :no_to_address} = CounterContract.get() |> Ethers.call()
-      assert {:error, :no_to_address} = CounterContract.set(101) |> Ethers.send_transaction(from: @from)
+
+      assert {:error, :no_to_address} =
+               CounterContract.set(101) |> Ethers.send_transaction(from: @from)
 
       assert {:error, :no_to_address} =
                CounterContract.set(101) |> Ethers.send_transaction(from: @from, gas: 100)
@@ -203,7 +208,10 @@ defmodule Ethers.CounterContractTest do
     test "returns the params when called" do
       assert %Ethers.TxData{
                base_module: CounterContract,
-               data: "0x60fe47b10000000000000000000000000000000000000000000000000000000000000065",
+               data:
+                 Utils.hex_decode!(
+                   "0x60fe47b10000000000000000000000000000000000000000000000000000000000000065"
+                 ),
                selector: %ABI.FunctionSelector{
                  function: "set",
                  method_id: <<96, 254, 71, 177>>,
@@ -223,7 +231,8 @@ defmodule Ethers.CounterContractTest do
     setup :deploy_counter_contract
 
     test "can get the emitted event with the correct filter", %{address: address} do
-      {:ok, tx_hash} = CounterContract.set(101) |> Ethers.send_transaction(from: @from, to: address)
+      {:ok, tx_hash} =
+        CounterContract.set(101) |> Ethers.send_transaction(from: @from, to: address)
 
       wait_for_transaction!(tx_hash)
 
@@ -245,7 +254,8 @@ defmodule Ethers.CounterContractTest do
     end
 
     test "cat get the emitted events with get_logs! function", %{address: address} do
-      {:ok, tx_hash} = CounterContract.set(101) |> Ethers.send_transaction(from: @from, to: address)
+      {:ok, tx_hash} =
+        CounterContract.set(101) |> Ethers.send_transaction(from: @from, to: address)
 
       wait_for_transaction!(tx_hash)
 
@@ -275,7 +285,8 @@ defmodule Ethers.CounterContractTest do
     end
 
     test "can filter logs with from_block and to_block options", %{address: address} do
-      {:ok, tx_hash} = CounterContract.set(101) |> Ethers.send_transaction(from: @from, to: address)
+      {:ok, tx_hash} =
+        CounterContract.set(101) |> Ethers.send_transaction(from: @from, to: address)
 
       wait_for_transaction!(tx_hash)
 

--- a/test/ethers/signer/json_rpc_test.exs
+++ b/test/ethers/signer/json_rpc_test.exs
@@ -2,12 +2,13 @@ defmodule Ethers.Signer.JsonRPCTest do
   use ExUnit.Case
 
   alias Ethers.Signer
+  alias Ethers.Utils
 
   describe "sign_transaction/2" do
     test "signs the transaction with the correct data" do
       transaction = %Ethers.Transaction.Eip1559{
         to: "0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0",
-        input: "0x06fdde03",
+        input: Utils.hex_decode!("0x06fdde03"),
         value: 0,
         chain_id: 31_337,
         nonce: 2918,
@@ -24,7 +25,7 @@ defmodule Ethers.Signer.JsonRPCTest do
     test "fails signing transaction with wrong from address" do
       transaction = %Ethers.Transaction.Eip1559{
         to: "0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0",
-        input: "0x06fdde03",
+        input: Utils.hex_decode!("0x06fdde03"),
         value: 0,
         chain_id: 31_337,
         nonce: 2918,

--- a/test/ethers_test.exs
+++ b/test/ethers_test.exs
@@ -16,6 +16,8 @@ defmodule EthersTest do
 
   import Ethers.TestHelpers
 
+  alias Ethers.Utils
+
   alias Ethers.Contract.Test.HelloWorldContract
   alias Ethers.Contract.Test.HelloWorldWithDefaultAddressContract
   alias Ethers.ExecutionError
@@ -354,7 +356,7 @@ defmodule EthersTest do
     test "is included in the function calls when has default address" do
       assert %Ethers.TxData{
                base_module: HelloWorldWithDefaultAddressContract,
-               data: "0xef5fb05b",
+               data: Utils.hex_decode!("0xef5fb05b"),
                selector: %ABI.FunctionSelector{
                  function: "sayHello",
                  method_id: <<239, 95, 176, 91>>,
@@ -369,7 +371,10 @@ defmodule EthersTest do
                default_address: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
              } == HelloWorldWithDefaultAddressContract.say_hello()
 
-      assert %{data: "0xef5fb05b", to: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"} ==
+      assert %{
+               data: Utils.hex_decode!("0xef5fb05b"),
+               to: "0x1000bf6a479f320ead074411a4b0e7944ea8c9c1"
+             } ==
                HelloWorldWithDefaultAddressContract.say_hello()
                |> Ethers.TxData.to_map([])
     end
@@ -377,7 +382,7 @@ defmodule EthersTest do
     test "is not included in the function calls when does not have default address" do
       assert %Ethers.TxData{
                base_module: HelloWorldContract,
-               data: "0xef5fb05b",
+               data: Utils.hex_decode!("0xef5fb05b"),
                selector: %ABI.FunctionSelector{
                  function: "sayHello",
                  method_id: <<239, 95, 176, 91>>,


### PR DESCRIPTION
- Updated `Ethers` module to use `Transaction.to_rpc_map` for `tx_params`.
- Simplified `pre_process` function in `Ethers` module by concatenating `contract_binary` and `encoded_constructor` directly.
- Removed unnecessary `hex_encode` calls in `Ethers.Contract` module.
- Decoded contract binary in `maybe_read_contract_binary` function in `Ethers.ContractHelpers`.
- Removed `hex_decode!` import and calls in `Ethers.Multicall` module.
- Simplified `new` function in `Ethers.Transaction` module by removing redundant `input` handling.
- Updated `to_rpc_map` function in `Ethers.Transaction` module to encode `data` and `input` fields.
- Removed `hex_decode!` call in `inspect` function in `Ethers.TxData` module.
- Updated tests to use `Utils.hex_decode!` where necessary.
