### PR TITLE
Recommend Ethers.Signature over the EOA-only verification helpers

### DIFF
--- a/lib/ethers/personal_message.ex
+++ b/lib/ethers/personal_message.ex
@@ -24,8 +24,10 @@ defmodule Ethers.PersonalMessage do
 
   Recovery and verification here are `ecrecover`-based and therefore work for
   externally-owned accounts (EOAs) only. Signatures from smart-contract wallets
-  (ERC-1271/ERC-6492) cannot be verified this way and need the RPC-backed
-  `Ethers.Signature` module.
+  (ERC-1271/ERC-6492) always fail these checks. Prefer
+  `Ethers.Signature.verify_message/4`, which verifies EOA and smart-contract wallet
+  signatures alike; use the functions here when you specifically need a pure, RPC-free
+  check for signatures known to come from EOA keys.
   """
 
   alias Ethers.ExecutionError
@@ -97,7 +99,8 @@ defmodule Ethers.PersonalMessage do
   comparison is done on the decoded 20-byte addresses, so checksum/case differences are
   ignored. Returns `false` (does not raise) when the signature is malformed.
 
-  EOA-only — for smart-contract wallets use the RPC-backed `Ethers.Signature` module.
+  EOA-only — prefer `Ethers.Signature.verify_message/4` to also support smart-contract
+  wallets (see "Verification scope" in the module docs).
 
   ## Examples
 

--- a/lib/ethers/typed_data.ex
+++ b/lib/ethers/typed_data.ex
@@ -352,6 +352,9 @@ defmodule Ethers.TypedData do
   `signature` may be given as a `0x`-prefixed hex string (130 hex chars) or a raw 65-byte binary
   (`r ‖ s ‖ v`).
 
+  Recovery is `ecrecover`-based and therefore works for externally-owned accounts (EOAs)
+  only — smart-contract wallets (ERC-1271/ERC-6492) do not have a recoverable signer.
+
   ## Returns
 
   - a checksummed `0x` address string on success.
@@ -388,6 +391,11 @@ defmodule Ethers.TypedData do
   comparison is done on the decoded 20-byte addresses, so checksum/case differences are ignored.
 
   `signature` may be a `0x`-prefixed hex string or a raw 65-byte binary.
+
+  EOA-only — signatures from smart-contract wallets (ERC-1271/ERC-6492) always fail this
+  check. Prefer `Ethers.Signature.verify_typed_data/4`, which verifies EOA and
+  smart-contract wallet signatures alike; use this function when you specifically need a
+  pure, RPC-free check for signatures known to come from EOA keys.
 
   ## Examples
 


### PR DESCRIPTION
Follow-up to #266. `Ethers.Signature.verify_typed_data/4` / `verify_message/4` already provide universal (EOA + ERC-1271 + ERC-6492) verification, but the EOA-only helpers didn't steer readers to them — backends using `Ethers.TypedData.valid_signature?/3` or `Ethers.PersonalMessage.verify/3` silently reject all smart-wallet users.

This documents those helpers (plus `recover_signer/2`, which is inherently EOA-only — contract wallets have no recoverable signer) with an explicit recommendation: prefer `Ethers.Signature` to support smart-contract wallets too; use the pure helpers when you specifically need an RPC-free check for signatures known to come from EOA keys.

Doc-only change; no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)